### PR TITLE
Added JSON marshaling support

### DIFF
--- a/urn.go
+++ b/urn.go
@@ -1,8 +1,12 @@
 package urn
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 )
+
+const errInvalidURN = "invalid URN: %s"
 
 // URN represents an Uniform Resource Name.
 //
@@ -60,4 +64,23 @@ func Parse(u []byte) (*URN, bool) {
 	}
 
 	return urn, true
+}
+
+// MarshalJSON marshals the URN to JSON string form (e.g. `"urn:oid:1.2.3.4"`).
+func (u URN) MarshalJSON() ([]byte, error) {
+	return json.Marshal(u.String())
+}
+
+// MarshalJSON unmarshals a URN from JSON string form (e.g. `"urn:oid:1.2.3.4"`).
+func (u *URN) UnmarshalJSON(bytes []byte) error {
+	var str string
+	if err := json.Unmarshal(bytes, &str); err != nil {
+		return err
+	}
+	if value, ok := Parse([]byte(str)); !ok {
+		return fmt.Errorf(errInvalidURN, str)
+	} else {
+		*u = *value
+	}
+	return nil
 }

--- a/urn_test.go
+++ b/urn_test.go
@@ -1,6 +1,7 @@
 package urn
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,4 +43,27 @@ func TestLexicalEquivalence(t *testing.T) {
 			t.Log("Something wrong in the testing table ...")
 		}
 	}
+}
+
+func TestJSONMarshaling(t *testing.T) {
+	t.Run("roundtrip", func(t *testing.T) {
+		// Marshal
+		expected := URN{ID: "oid", SS: "1.2.3.4"}
+		bytes, err := json.Marshal(expected)
+		if !assert.NoError(t, err) {
+			return
+		}
+		// Unmarshal
+		var actual URN
+		err = json.Unmarshal(bytes, &actual)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, expected.String(), actual.String())
+	})
+	t.Run("invalid URN", func(t *testing.T) {
+		var actual URN
+		err := json.Unmarshal([]byte(`"not a URN"`), &actual)
+		assert.EqualError(t, err, "invalid URN: not a URN")
+	})
 }


### PR DESCRIPTION
First of all thank you for the library.

One thing I missed (when trying to use it for https://github.com/nuts-foundation/) was proper support for JSON marshaling since it marshalled the struct fields instead of a more generic string format (e.g. urn:oid:1.2.3.4). So here it is.