### PR TITLE
Add scim (rfc 7643) specific struct

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -2,6 +2,7 @@ package urn_test
 
 import (
 	"fmt"
+
 	"github.com/leodido/go-urn"
 )
 
@@ -50,4 +51,24 @@ func ExampleURN_Equal() {
 	}
 
 	// Output: URN:foo:a123,456 equals URN:FOO:a123,456
+}
+
+func ExampleParseAsSCIM() {
+	var scimURN = "urn:ietf:params:scim:schemas:core:2.0:User"
+
+	s, err := urn.ParseAsSCIM([]byte(scimURN))
+	if err == nil {
+		fmt.Println(s.URN().ID)
+		fmt.Println(s.URN().SS)
+		fmt.Println(s.Type)
+		fmt.Println(s.Name)
+		fmt.Println(s.Other)
+	}
+
+	// Output:
+	// ietf
+	// params:scim:schemas:core:2.0:User
+	// schemas
+	// core
+	// 2.0:User
 }

--- a/scim.go
+++ b/scim.go
@@ -1,0 +1,74 @@
+package urn
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+var (
+	subNamespaceForSCIM      = []byte("urn:ietf:params:scim")
+	subNamespaceForSCIMIndex = len(subNamespaceForSCIM) + 1
+	subNamespaceForSCIMTypes = []string{"schemas", "api"}
+)
+
+// SCIM represents an URN Sub-namespace for SCIM described in https://www.ietf.org/rfc/rfc7643.txt
+type SCIM struct {
+	urn   *URN   // Uniform Resource Name
+	Type  string // The entity type for SCIM
+	Name  string // Defined a major namespace of a schema within SCIM
+	Other string // Defined a sub-namespace as needed to uniquely identify a schema
+}
+
+// URN returns general URN
+func (s *SCIM) URN() *URN {
+	return s.urn
+}
+
+// String reassembles the URN into a valid URN string.
+func (s *SCIM) String() string {
+	return s.urn.String()
+}
+
+// MarshalJSON marshals the URN to JSON string form (e.g. `"urn:oid:1.2.3.4"`).
+func (s *SCIM) MarshalJSON() ([]byte, error) {
+	return s.urn.MarshalJSON()
+}
+
+// UnmarshalJSON unmarshals a URN from JSON string form (e.g. `"urn:oid:1.2.3.4"`).
+func (s *SCIM) UnmarshalJSON(bytes []byte) error {
+	return s.urn.UnmarshalJSON(bytes)
+}
+
+func hasSCIMTypes(s string) bool {
+	for i := range subNamespaceForSCIMTypes {
+		if subNamespaceForSCIMTypes[i] == s {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseAsSCIM is responsible to create an SCIM instance from a byte array.
+func ParseAsSCIM(b []byte) (*SCIM, error) {
+	urn, ok := Parse(b)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse: invalid URN")
+	}
+	if !bytes.HasPrefix(b, subNamespaceForSCIM) {
+		return nil, fmt.Errorf("faled to parse: invalid SCIM Sub-namespace")
+	}
+	r := strings.SplitN(string(b[subNamespaceForSCIMIndex:]), ":", 3)
+	typ, name, other := r[0], r[1], r[2]
+	if !hasSCIMTypes(typ) {
+		return nil, fmt.Errorf(
+			`got invalid type in SCIM Sub-namespace, `+
+				`either "schemas" or "api": %s`, typ)
+	}
+	return &SCIM{
+		urn:   urn,
+		Type:  typ,
+		Name:  name,
+		Other: other,
+	}, nil
+}

--- a/scim_test.go
+++ b/scim_test.go
@@ -1,0 +1,101 @@
+package urn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalParseAsSCIM(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       []byte
+		expected *SCIM
+	}{
+		{
+			"simple scim sub-namespace with schemas type",
+			[]byte("urn:ietf:params:scim:schemas:core:2.0:User"),
+			&SCIM{
+				urn: &URN{
+					prefix: "urn",
+					ID:     "ietf",
+					SS:     "params:scim:schemas:core:2.0:User",
+					norm:   "params:scim:schemas:core:2.0:User",
+				},
+				Type:  "schemas",
+				Name:  "core",
+				Other: "2.0:User",
+			},
+		},
+		{
+			"complex scim sub-namespace with schemas type",
+			[]byte("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:meta.lastModified"),
+			&SCIM{
+				urn: &URN{
+					prefix: "urn",
+					ID:     "ietf",
+					SS:     "params:scim:schemas:extension:enterprise:2.0:User:meta.lastModified",
+					norm:   "params:scim:schemas:extension:enterprise:2.0:User:meta.lastModified",
+				},
+				Type:  "schemas",
+				Name:  "extension",
+				Other: "enterprise:2.0:User:meta.lastModified",
+			},
+		},
+		{
+			"simple scim sub-namespace with api type",
+			[]byte("urn:ietf:params:scim:api:messages:2.0:ListResponse"),
+			&SCIM{
+				urn: &URN{
+					prefix: "urn",
+					ID:     "ietf",
+					SS:     "params:scim:api:messages:2.0:ListResponse",
+					norm:   "params:scim:api:messages:2.0:ListResponse",
+				},
+				Type:  "api",
+				Name:  "messages",
+				Other: "2.0:ListResponse",
+			},
+		},
+	}
+	for _, tt := range tests {
+		actual, err := ParseAsSCIM(tt.in)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, tt.expected, actual)
+	}
+}
+
+func TestErrorParseAsSCIM(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       []byte
+		expected string
+	}{
+		{
+			"invalid urn string",
+			[]byte("urn-ietf-params"),
+			"failed to parse: invalid URN",
+		},
+		{
+			"invalid scim sub-namespace",
+			[]byte("urn:ietf:param:ext-scim:schemas:core:2.0:User"),
+			"faled to parse: invalid SCIM Sub-namespace",
+		},
+
+		{
+			"invalid scim sub-namespace",
+			[]byte("urn:ietf:params:scim:model:core:2.0:User"),
+			`got invalid type in SCIM Sub-namespace, either "schemas" or "api": model`,
+		},
+	}
+	for _, tt := range tests {
+		_, err := ParseAsSCIM(tt.in)
+		assert.Error(t, err, tt.in)
+		if tt.expected != err.Error() {
+			t.Errorf("want '%s' as an error message, but got '%s'",
+				tt.expected, err.Error())
+		}
+	}
+}

--- a/urn.go
+++ b/urn.go
@@ -71,7 +71,7 @@ func (u URN) MarshalJSON() ([]byte, error) {
 	return json.Marshal(u.String())
 }
 
-// MarshalJSON unmarshals a URN from JSON string form (e.g. `"urn:oid:1.2.3.4"`).
+// UnmarshalJSON unmarshals a URN from JSON string form (e.g. `"urn:oid:1.2.3.4"`).
 func (u *URN) UnmarshalJSON(bytes []byte) error {
 	var str string
 	if err := json.Unmarshal(bytes, &str); err != nil {


### PR DESCRIPTION
I implemented the parse function to return the SCIM-specific value. Could you review it?

## References

* https://github.com/leodido/go-urn/issues/32
* https://datatracker.ietf.org/doc/html/rfc7643#section-10