### PR TITLE
Remove param from SCIM types

### DIFF
--- a/scim/schema/type.go
+++ b/scim/schema/type.go
@@ -6,7 +6,6 @@ const (
 	Unsupported Type = iota
 	Schemas
 	API
-	Param
 )
 
 func (t Type) String() string {
@@ -15,8 +14,6 @@ func (t Type) String() string {
 		return "schemas"
 	case API:
 		return "api"
-	case Param:
-		return "param"
 	}
 
 	return ""
@@ -28,8 +25,6 @@ func TypeFromString(input string) Type {
 		return Schemas
 	case "api":
 		return API
-	case "param":
-		return Param
 	}
 
 	return Unsupported

--- a/scim/schema/type_test.go
+++ b/scim/schema/type_test.go
@@ -18,8 +18,4 @@ func TestTypeFromString(t *testing.T) {
 	api := TypeFromString("api")
 	require.Equal(t, API, api)
 	require.Equal(t, "api", api.String())
-
-	param := TypeFromString("param")
-	require.Equal(t, Param, param)
-	require.Equal(t, "param", param.String())
 }


### PR DESCRIPTION
According to https://datatracker.ietf.org/doc/html/rfc7643#section-10.2.1, there is no `param` in the type definition.

>      type
>         The entity type, which is either "schemas" or "api".